### PR TITLE
Fix several instances of charset conversion creating issues in code

### DIFF
--- a/src/divc.c
+++ b/src/divc.c
@@ -1205,7 +1205,7 @@ free_resources();
   // _case_sensitive
   memcpy(lower+129,"ueaaaaçeeeiiiaaeææooouuyouø£Ø×ƒaiou",35);
   memcpy(lower+'A',"abcdefghijklmnopqrstuvwxyz",26);
-  lower['Ñ']='ñ';
+  lower['\xa5' /*'Ñ'*/]='\xa4' /*'ñ'*/;
 
   comp_exit();
 

--- a/src/divhandl.c
+++ b/src/divhandl.c
@@ -1100,7 +1100,7 @@ void imp_fontmap(void) {
   if (*(int*)(buffer+1356+'A'*16)) gencode|=2;
   if (*(int*)(buffer+1356+'a'*16)) gencode|=4;
   if (*(int*)(buffer+1356+'?'*16)) gencode|=8;
-  if (*(int*)(buffer+1356+'ñ'*16)) gencode|=16;
+  if (*(int*)(buffer+1356+'\xa4'*16)) gencode|=16; // ñ
 
   memcpy(buffer+1352,&gencode,4);
 

--- a/src/divpaint.c
+++ b/src/divpaint.c
@@ -2873,7 +2873,7 @@ void mover(byte * sp, int an, int al) {
       xg=ang*57.295779761; if (xg<0) xg+=360;
       wbox(barra,vga_an/big2,19,c2,barra_an-23,2,21,15);
       p=copia; copia=barra; text_color=c3;
-      num[4]=0; num[3]='º'; num[2]=xg%10+48; num[1]=(xg/10)%10+48;
+      num[4]=0; num[3]='\xa7'/*'º'*/; num[2]=xg%10+48; num[1]=(xg/10)%10+48;
       num[0]=(xg/100)%10+48; writetxt(barra_an-21,6,0,num); copia=p;
     }
 

--- a/src/runtime/debug/d.c
+++ b/src/runtime/debug/d.c
@@ -328,7 +328,7 @@ void init_debug(void) {
     if (o[n].tipo==tcglo || o[n].tipo==tcloc) visor[n]=2;
     if (o[n].tipo==tcons && o[n].v1==1) visor[n]=2;
     if ((o[n].tipo==tvloc || o[n].tipo==tvglo || o[n].tipo==tcons) &&
-       (vnom[o[n].nombre]=='a' || vnom[o[n].nombre]=='á') &&
+       (vnom[o[n].nombre]=='a' || vnom[o[n].nombre]=='\xa0' /*á*/) &&
        vnom[o[n].nombre+1]=='n' && vnom[o[n].nombre+2]=='g') visor[n]=4;
     if (o[n].tipo==tcons && !strcmp(vnom+o[n].nombre,"pi")) visor[n]=4;
     if ((o[n].tipo==tvloc || o[n].tipo==tvglo) &&


### PR DESCRIPTION
When converting to UTF8, some characters now no longer fit in 1 byte. Use the actual original (CP850 charset) value of those characters instead

There's still 3 other places in divc.c with similar issues, but they're either a bit more complex or feel like an outright bug. I'll try to take a look tomorrow.